### PR TITLE
使用fs.realpathSync判断文件路径是否包含mockDataDir

### DIFF
--- a/src/App/services/mockData.ts
+++ b/src/App/services/mockData.ts
@@ -160,7 +160,12 @@ export class MockDataService extends EventEmitter {
    * @private
    */
   private _getDataFilePath(userId, dataId) {
-    return path.join(this.mockDataDir, userId + '_' + dataId);
+    const dataFileRealPath = fs.realpathSync(path.join(this.mockDataDir, userId + '_' + dataId));
+    if (dataFileRealPath.includes(this.mockDataDir)){
+      return path.join(this.mockDataDir, userId + '_' + dataId);
+    }else {
+      return '';
+    }
   }
 
   /**


### PR DESCRIPTION
修复 https://github.com/youzan/zan-proxy/issues/12