### PR TITLE
4.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Github Change Log
 
+## zan-proxy@4.0.14 (2018-07-05)
+
+**Implemented enhancements:**
+
+- [支持Host多选](https://github.com/youzan/zan-proxy/issues/24)
+- [支持转发规则集信息编辑](https://github.com/youzan/zan-proxy/pull/30)
+- [使用fs.realpathSync判断dataFileRealPath是否包含mockDataDir](https://github.com/youzan/zan-proxy/pull/25)
+- 优化构建命令
+- 增加更新提示
+
+**Fixed bugs:**
+
+- [修复@types/node版本过高导致构建失败的问题](https://github.com/youzan/zan-proxy/issues/27)
+- [删除特殊字符的规则时报错](https://github.com/youzan/zan-proxy/pull/28)
+- 修复监控器请求数据展示异常
+- 兼容没有action的老数据
+
 ## zan-proxy@4.0.11 ~ 4.0.13 (2018-06-12)
 
 **Implemented enhancements:**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.13",
   "description": "前端代理",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cd ./webui && npm run build && cd ../",
     "test": "HOME=/tmp/proxy-test nyc mocha -r ts-node/register -c --recursive 'test/**/**/*.spec.ts'",
     "watch": "tsc --watch",
     "postinstall": "node ./scripts/resetDataFile.js",
@@ -50,7 +50,7 @@
     "@types/chai": "^4.1.2",
     "@types/lru-cache": "^4.1.0",
     "@types/mocha": "^5.0.0",
-    "@types/node": "^9.4.7",
+    "@types/node": "<=9.6.13",
     "chai": "^4.1.2",
     "chai-events": "^0.0.1",
     "mocha": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zan-proxy",
-  "version": "4.0.13",
+  "version": "4.0.14",
   "description": "前端代理",
   "scripts": {
     "build": "tsc && cd ./webui && npm run build && cd ../",

--- a/scripts/resetDataFile.js
+++ b/scripts/resetDataFile.js
@@ -108,7 +108,7 @@ function convertRuleFile(oldRuleFile) {
     newRuleFile.content = newRuleFile
         .content
         .filter((rule) => {
-            return rule.action.type === "redirect"; // 其他action暂时不支持
+            return rule.action && rule.action.type === "redirect"; // 其他action暂时不支持
         })
         .map(convertRule);
     return newRuleFile;

--- a/src/App/manager/controller/host.ts
+++ b/src/App/manager/controller/host.ts
@@ -38,10 +38,11 @@ export class HostController {
         code: 0,
       };
     });
-    // /host/usefile?name=${name}
-    router.get('/host/usefile', async ctx => {
+    // /host/togglefile?name=${name}
+    router.get('/host/togglefile', async ctx => {
       const userId = ctx.userId;
-      await this.hostService.setUseHost(userId, ctx.query.name);
+      const { name } = ctx.query;
+      await this.hostService.toggleUseHost(userId, name);
       ctx.body = {
         code: 0,
       };

--- a/src/App/manager/controller/rule.ts
+++ b/src/App/manager/controller/rule.ts
@@ -1,6 +1,6 @@
 import Router from 'koa-router';
 import { Inject, Service } from 'typedi';
-import { ProfileService, RuleService } from '../../services';
+import { ProfileService, RuleService, ErrNameExists } from '../../services';
 /**
  * Created by tsxuehu on 4/11/17.
  */
@@ -20,15 +20,24 @@ export class RuleController {
     });
     ruleRouter.post('/create', async ctx => {
       const userId = ctx.userId;
-      const result = await this.ruleService.createRuleFile(
-        userId,
-        ctx.request.body.name,
-        ctx.request.body.description,
-      );
-      ctx.body = {
-        code: result ? 0 : 1,
-        msg: result ? '' : '文件已存在',
-      };
+      try {
+        const result = await this.ruleService.createRuleFile(
+          userId,
+          ctx.request.body.name,
+          ctx.request.body.description,
+        );
+        ctx.body = {
+          code: 0,
+          msg: result,
+        };
+        return;
+      } catch (error) {
+        const msg = error === ErrNameExists ? '文件已存在' : `未知错误: ${error.toString()}`;
+        ctx.body = {
+          code: 1,
+          msg,
+        };
+      }
     });
     // 获取规则文件列表
     // /rule/filelist
@@ -99,9 +108,26 @@ export class RuleController {
     });
 
     // 重命名规则文件
-    // /rule/changefilename?newName=${name}, body -> RuleFile
-    ruleRouter.post('/changefilename', async ctx => {
-      ctx.body = await this.ruleService.changeRuleFileName(ctx.userId, ctx.request.body, ctx.query.newName, ctx.query.newDescription);
+    // /rule/changefilename/:origin, body -> { name, description }
+    ruleRouter.post('/updatefileinfo/:origin', async ctx => {
+      const { userId, params, request } = ctx;
+      const { origin } = params;
+      const { name, description } = request.body;
+      try {
+        await this.ruleService.updateFileInfo(userId, origin, {
+          description,
+          name,
+        });
+        ctx.body = {
+          code: 0,
+        };
+      } catch (e) {
+        const msg = e === ErrNameExists ? '有重复名字' : `未知错误: ${e.toString()}`;
+        ctx.body = {
+          code: 1,
+          msg,
+        };
+      }
     });
 
     // 导出规则文件

--- a/src/App/manager/controller/rule.ts
+++ b/src/App/manager/controller/rule.ts
@@ -32,7 +32,10 @@ export class RuleController {
         };
         return;
       } catch (error) {
-        const msg = error === ErrNameExists ? '文件已存在' : `未知错误: ${error.toString()}`;
+        const msg =
+          error === ErrNameExists
+            ? '文件已存在'
+            : `未知错误: ${error.toString()}`;
         ctx.body = {
           code: 1,
           msg,
@@ -122,7 +125,8 @@ export class RuleController {
           code: 0,
         };
       } catch (e) {
-        const msg = e === ErrNameExists ? '有重复名字' : `未知错误: ${e.toString()}`;
+        const msg =
+          e === ErrNameExists ? '有重复名字' : `未知错误: ${e.toString()}`;
         ctx.body = {
           code: 1,
           msg,

--- a/src/App/services/host.ts
+++ b/src/App/services/host.ts
@@ -233,20 +233,19 @@ export class HostService extends EventEmitter {
       // 读文件加载host
       const hostMap = {};
       const globHostMap = {};
-      Object.keys(this.userHostFilesMap[userId])
-        .forEach(name => {
-          const file = this.userHostFilesMap[userId][name];
-          if (!file.checked) {
-              return;
+      Object.keys(this.userHostFilesMap[userId]).forEach(name => {
+        const file = this.userHostFilesMap[userId][name];
+        if (!file.checked) {
+          return;
+        }
+        forEach(file.content, (ip, host) => {
+          if (host.startsWith('*')) {
+            globHostMap[host.substr(1, host.length)] = ip;
+          } else {
+            hostMap[host] = ip;
           }
-          forEach(file.content, (ip, host) => {
-            if (host.startsWith('*')) {
-              globHostMap[host.substr(1, host.length)] = ip;
-            } else {
-              hostMap[host] = ip;
-            }
-          });
         });
+      });
       hosts = {
         globHostMap,
         hostMap,

--- a/src/App/services/host.ts
+++ b/src/App/services/host.ts
@@ -66,9 +66,6 @@ export class HostService extends EventEmitter {
     let ip;
     const inUsingHosts = this.getInUsingHosts(userId);
     ip = inUsingHosts.hostMap[hostname];
-    if (ip) {
-      return ip;
-    }
     // 配置 *开头的host  计算属性globHostMap已经将*去除
     ip = find(inUsingHosts.globHostMap, (_, host) => {
       return hostname.endsWith(host);
@@ -149,14 +146,11 @@ export class HostService extends EventEmitter {
     this.emit('host-deleted', userId, name);
   }
 
-  public async setUseHost(userId, filename) {
+  public async toggleUseHost(userId, filename) {
     const toSaveFileName: string[] = [];
     forEach(this.userHostFilesMap[userId], (content, name) => {
-      if (content.name === filename && content.checked !== true) {
-        content.checked = true;
-        toSaveFileName.push(name);
-      } else if (content.name !== filename && content.checked !== false) {
-        content.checked = false;
+      if (content.name === filename) {
+        content.checked = !content.checked;
         toSaveFileName.push(name);
       }
     });
@@ -239,18 +233,20 @@ export class HostService extends EventEmitter {
       // 读文件加载host
       const hostMap = {};
       const globHostMap = {};
-      const findedUsingHost = find(this.userHostFilesMap[userId], content => {
-        return content.checked;
-      });
-      if (findedUsingHost) {
-        forEach(findedUsingHost.content, (ip, host) => {
-          if (host.startsWith('*')) {
-            globHostMap[host.substr(1, host.length)] = ip;
-          } else {
-            hostMap[host] = ip;
+      Object.keys(this.userHostFilesMap[userId])
+        .forEach(name => {
+          const file = this.userHostFilesMap[userId][name];
+          if (!file.checked) {
+              return;
           }
+          forEach(file.content, (ip, host) => {
+            if (host.startsWith('*')) {
+              globHostMap[host.substr(1, host.length)] = ip;
+            } else {
+              hostMap[host] = ip;
+            }
+          });
         });
-      }
       hosts = {
         globHostMap,
         hostMap,

--- a/src/App/services/mockData.ts
+++ b/src/App/services/mockData.ts
@@ -160,11 +160,10 @@ export class MockDataService extends EventEmitter {
    * @private
    */
   private _getDataFilePath(userId, dataId) {
-    const dataFileRealPath = fs.realpathSync(
-      path.join(this.mockDataDir, userId + '_' + dataId),
-    );
+    const p = path.join(this.mockDataDir, userId + '_' + dataId);
+    const dataFileRealPath = fs.realpathSync(p);
     if (dataFileRealPath.includes(this.mockDataDir)) {
-      return path.join(this.mockDataDir, userId + '_' + dataId);
+      return p;
     } else {
       return '';
     }

--- a/src/App/services/mockData.ts
+++ b/src/App/services/mockData.ts
@@ -160,10 +160,12 @@ export class MockDataService extends EventEmitter {
    * @private
    */
   private _getDataFilePath(userId, dataId) {
-    const dataFileRealPath = fs.realpathSync(path.join(this.mockDataDir, userId + '_' + dataId));
-    if (dataFileRealPath.includes(this.mockDataDir)){
+    const dataFileRealPath = fs.realpathSync(
+      path.join(this.mockDataDir, userId + '_' + dataId),
+    );
+    if (dataFileRealPath.includes(this.mockDataDir)) {
       return path.join(this.mockDataDir, userId + '_' + dataId);
-    }else {
+    } else {
       return '';
     }
   }

--- a/src/App/services/rule.ts
+++ b/src/App/services/rule.ts
@@ -203,13 +203,17 @@ export class RuleService extends EventEmitter {
   }
 
   // 修改规则文件名称
-  public async updateFileInfo(userId, originName: string, {
-    name,
-    description,
-  }: {
-    name: string,
-    description: string,
-  }) {
+  public async updateFileInfo(
+    userId,
+    originName: string,
+    {
+      name,
+      description,
+    }: {
+      name: string;
+      description: string;
+    },
+  ) {
     const userRuleMap = this.rules[userId] || {};
     if (userRuleMap[name]) {
       throw ErrNameExists;

--- a/src/App/services/rule.ts
+++ b/src/App/services/rule.ts
@@ -11,6 +11,7 @@ import { AppInfoService } from './appInfo';
 
 const jsonfileWriteFile = promisify(jsonfile.writeFile);
 const fsUnlink = promisify(fs.unlink);
+export const ErrNameExists = new Error('name exists');
 
 export interface Rule {
   name: string;
@@ -84,7 +85,7 @@ export class RuleService extends EventEmitter {
   // 创建规则文件
   public async createRuleFile(userId, name, description) {
     if (this.rules[userId] && this.rules[userId][name]) {
-      return false;
+      return ErrNameExists;
     }
     const ruleFile = {
       checked: false,
@@ -202,42 +203,27 @@ export class RuleService extends EventEmitter {
   }
 
   // 修改规则文件名称
-  public async changeRuleFileName(userId, ruleFile: RuleFile, newName: string, newDescription: string) {
-    const oldName = ruleFile.name;
+  public async updateFileInfo(userId, originName: string, {
+    name,
+    description,
+  }: {
+    name: string,
+    description: string,
+  }) {
     const userRuleMap = this.rules[userId] || {};
-    if (userRuleMap[newName]) {
-      return {
-        code: -1,
-        msg: `名称为"${newName}"的规则集已存在!`,
-      };
+    if (userRuleMap[name]) {
+      throw ErrNameExists;
     }
-
+    const ruleFile = userRuleMap[originName];
     // 删除旧的rule
-    delete this.rules[userId][oldName];
-    const ruleFilePath = this._getRuleFilePath(userId, oldName);
+    delete this.rules[userId][originName];
+    const ruleFilePath = this._getRuleFilePath(userId, originName);
     await fsUnlink(ruleFilePath);
 
     // 修改rule名称
-    ruleFile.name = newName;
-    ruleFile.description = newDescription;
-    userRuleMap[newName] = ruleFile;
-    this.rules[userId] = userRuleMap;
-
-    // 写文件
-    const filePath = this._getRuleFilePath(userId, newName);
-    await jsonfileWriteFile(filePath, userRuleMap[newName], {
-      encoding: 'utf-8',
-    });
-
-    // 清空缓存
-    delete this.usingRuleCache[userId];
-
-    // 发送消息通知
-    this.emit('data-change', userId, this.getRuleFileList(userId));
-
-    return {
-      code: 0,
-    };
+    ruleFile.name = name;
+    ruleFile.description = description;
+    await this.saveRuleFile(userId, ruleFile);
   }
 
   /**

--- a/src/ProxyServer/impl/handler/connect.ts
+++ b/src/ProxyServer/impl/handler/connect.ts
@@ -30,18 +30,22 @@ export class ConnectHandler implements IConnectHandler {
     }
     let IPKey;
     // 和远程建立链接 并告诉客户端
-    const conn = net.connect(proxyPort, proxyHost, () => {
-      IPKey = this._getIPKey(conn.address().port);
-      this.cache.set(IPKey, socket.remoteAddress);
-      socket.write(
-        'HTTP/' + req.httpVersion + ' 200 OK\r\n\r\n',
-        'UTF-8',
-        () => {
-          conn.pipe(socket);
-          socket.pipe(conn);
-        },
-      );
-    });
+    const conn = net.connect(
+      proxyPort,
+      proxyHost,
+      () => {
+        IPKey = this._getIPKey(conn.address().port);
+        this.cache.set(IPKey, socket.remoteAddress);
+        socket.write(
+          'HTTP/' + req.httpVersion + ' 200 OK\r\n\r\n',
+          'UTF-8',
+          () => {
+            conn.pipe(socket);
+            socket.pipe(conn);
+          },
+        );
+      },
+    );
 
     conn.on('error', e => {
       console.error(e);

--- a/src/ProxyServer/impl/handler/connect.ts
+++ b/src/ProxyServer/impl/handler/connect.ts
@@ -30,22 +30,18 @@ export class ConnectHandler implements IConnectHandler {
     }
     let IPKey;
     // 和远程建立链接 并告诉客户端
-    const conn = net.connect(
-      proxyPort,
-      proxyHost,
-      () => {
-        IPKey = this._getIPKey(conn.address().port);
-        this.cache.set(IPKey, socket.remoteAddress);
-        socket.write(
-          'HTTP/' + req.httpVersion + ' 200 OK\r\n\r\n',
-          'UTF-8',
-          () => {
-            conn.pipe(socket);
-            socket.pipe(conn);
-          },
-        );
-      },
-    );
+    const conn = net.connect(proxyPort, proxyHost, () => {
+      IPKey = this._getIPKey(conn.address().port);
+      this.cache.set(IPKey, socket.remoteAddress);
+      socket.write(
+        'HTTP/' + req.httpVersion + ' 200 OK\r\n\r\n',
+        'UTF-8',
+        () => {
+          conn.pipe(socket);
+          socket.pipe(conn);
+        },
+      );
+    });
 
     conn.on('error', e => {
       console.error(e);

--- a/src/bin/selfUpdate.ts
+++ b/src/bin/selfUpdate.ts
@@ -33,7 +33,11 @@ export default async () => {
     .then(() => exec(`npm install --global --silent ${packageInfo.name}`))
     .then(() => {
       updateSpinner.stop();
-      console.log(`更新完成，请重新启动! 如出现命令丢失情况，请手动重新安装：npm install -g ${packageInfo.name}`);
+      console.log(
+        `更新完成，请重新启动! 如出现命令丢失情况，请手动重新安装：npm install -g ${
+          packageInfo.name
+        }`,
+      );
       process.exit(0);
     })
     .catch(error => {

--- a/src/bin/selfUpdate.ts
+++ b/src/bin/selfUpdate.ts
@@ -33,7 +33,7 @@ export default async () => {
     .then(() => exec(`npm install --global --silent ${packageInfo.name}`))
     .then(() => {
       updateSpinner.stop();
-      console.log('更新完成，请重新启动!');
+      console.log(`更新完成，请重新启动! 如出现命令丢失情况，请手动重新安装：npm install -g ${packageInfo.name}`);
       process.exit(0);
     })
     .catch(error => {

--- a/test/App/services/host.spec.ts
+++ b/test/App/services/host.spec.ts
@@ -98,7 +98,7 @@ describe("HostService", () => {
             },
             name: "test2",
         });
-        await hostService.setUseHost("root", "test2");
+        await hostService.toggleUseHost("root", "test2");
         const address = await hostService.resolveHost("root", "test.youzan.com");
         address.should.equal("192.168.1.1");
         await hostService.deleteHostFile("root", "test2");

--- a/webui/package.json
+++ b/webui/package.json
@@ -18,7 +18,6 @@
     "is-json": "^2.0.1",
     "jquery": "^3.1.1",
     "lodash": "^4.17.4",
-    "prettysize": "^1.1.0",
     "prettytime": "^1.0.0",
     "qrcode-js": "0.0.2",
     "query-string": "^4.3.4",

--- a/webui/src/api/host.js
+++ b/webui/src/api/host.js
@@ -23,8 +23,8 @@ var api = {
     deleteFile(name){
         return axios.get(`/host/deletefile?name=${name}`);
     },
-    useFile(name){
-        return axios.get(`/host/usefile?name=${name}`);
+    toggleFile(name){
+        return axios.get(`/host/togglefile?name=${name}`);
     },
     getFileContent(name){
         return axios.get(`/host/getfile?name=${name}`);
@@ -37,7 +37,7 @@ var api = {
     },
 };
 api.debouncedUseFile = _.debounce(function (name, callback) {
-    api.useFile(name).then((response) => {
+    api.toggleFile(name).then((response) => {
         callback(response)
     });
 }, 500);

--- a/webui/src/api/rule.js
+++ b/webui/src/api/rule.js
@@ -35,12 +35,12 @@ var api = {
 
   /**
    * 修改规则集文件名
-   * @param {String} newName 新名称
-   * @param {String} newDescription 新描述
-   * @param {Object} content 规则集内容
+   * @param {String} origin 原名称
+   * @param {String} name 新名称
+   * @param {String} description 新描述
    */
-  changeFileName(newName, newDescription, content) {
-    return axios.post(`/rule/changefilename?newName=${encodeURIComponent(newName)}&newDescription=${newDescription}`, content);
+  updateFileInfo(origin, { name, description }) {
+    return axios.post(`/rule/updatefileinfo/${encodeURIComponent(origin)}`, { name, description });
   },
 
   testRule(content){

--- a/webui/src/manager/components/host/FileList.vue
+++ b/webui/src/manager/components/host/FileList.vue
@@ -12,7 +12,7 @@
     <el-table border align='center' :data="$dc.hostFileList">
       <el-table-column prop="checked" label="启用" width="85">
         <template scope='scope'>
-          <el-radio v-model="selectedFileName" :label="scope.row.name" :disabled="!$dc.hostState" />
+          <el-checkbox :checked="scope.row.checked" @change="toggleFile(scope.row.name)" :disabled="!$dc.hostState" />
         </template>
       </el-table-column>
       <el-table-column prop="name" label="名字" width="150">
@@ -47,28 +47,6 @@
 
   export default {
     name: 'hostlist',
-
-    computed: {
-      selectedFileName: {
-        get(){
-          // 遍历找出选择的文件
-          var selectedFile = _.find(this.$dc.hostFileList, (file) => {
-            return file.checked;
-          });
-          return selectedFile ? selectedFile.name : '';
-        },
-        set(value){
-          this.$dc.hostFileList.forEach(function (row) {
-              if (row.name != value) {
-                  row.checked = false;
-              } else {
-                  row.checked = true;
-              }
-          });
-          this.useFile(value);
-        }
-      }
-    },
     methods: {
       onDeleteFile(row, index, list) {
         this.$confirm(`此操作将永久删除该文件: ${row.name}, 是否继续?`, '提示', {
@@ -89,7 +67,7 @@
           });
         })
       },
-      useFile(name) {
+      toggleFile(name) {
           hostApi.debouncedUseFile(name, (response) => {
           var serverData = response.data;
           if (serverData.code == 0) {

--- a/webui/src/manager/components/rule/EditRule.vue
+++ b/webui/src/manager/components/rule/EditRule.vue
@@ -4,7 +4,7 @@
     <span class="save-tip" v-if="loaded && filecontent.meta && filecontent.meta.remote">该规则集为远程规则集，重启同步后相关配置会被覆盖。如需永久保存修改，则可以复制该规则集成本地规则集。</span>
     <el-row :gutter="20" style="margin-bottom: 10px;text-align: right;">
       <el-col :span="6" :offset="18">
-        <el-button size="small" @click='openEditRuleNameDialog'>设置</el-button>
+        <el-button size="small" @click='openEditRuleInfoDialog'>编辑名字/描述</el-button>
         <el-button size="small" @click='addRule'>新增规则</el-button>
         <!-- <el-button size="small" type="primary" @click='saveFileRightNow'>保存规则集</el-button> -->
       </el-col>
@@ -95,7 +95,7 @@
     <edit-dialog :visible="dialogVisible" :save="dialogSave" :cancel="hideEditDialog" :initRule="editingRule"></edit-dialog>
     <edit-rule-config-dialog
       :visible="editRuleConfigDialogVisible"
-      :ok="changeFileName"
+      :ok="updateFileInfo"
       :cancel="closeEditRuleNameDialog"
       :defaultName="filecontent.name"
       :defaultDescription="filecontent.description"
@@ -286,18 +286,21 @@
         this.hideEditDialog();
         this.saveFileRightNow();
       },
-      openEditRuleNameDialog() {
+      openEditRuleInfoDialog() {
         this.editRuleConfigDialogVisible = true;
       },
       closeEditRuleNameDialog() {
         this.editRuleConfigDialogVisible = false;
       },
-      async changeFileName(newName, newDescription) {
+      async updateFileInfo(newName, newDescription) {
         let errMessage = '';
         if (newName === '') {
           errMessage = '规则集名称不能为空!';
         } else {
-          const {status, data} = await ruleApi.changeFileName(newName, newDescription, this.filecontent);
+          const {status, data} = await ruleApi.updateFileInfo(this.filecontent.name, {
+            name: newName,
+            description: newDescription,
+          });
           if (status !== 200) {
             errMessage = '请求失败';
           } else if (data.code !== 0) {

--- a/webui/src/manager/components/rule/EditRuleConfigDialog.vue
+++ b/webui/src/manager/components/rule/EditRuleConfigDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <el-dialog title="设置" :visible.sync="dialogVisible" @close="cancel">
+    <el-dialog title="编辑" :visible.sync="dialogVisible" @close="cancel">
         <el-form>
             <el-form-item label="规则集名称" label-width="120px">
                <el-input v-model="name" auto-complete="off"></el-input>

--- a/webui/src/monitor/components/RecordTable/index.vue
+++ b/webui/src/monitor/components/RecordTable/index.vue
@@ -87,7 +87,7 @@
 
 import { getStatusText } from 'http-status-codes'
 
-import prettySize from 'prettysize'
+import prettySize from './prettySize'
 import prettyTime from 'prettytime'
 
 const contentTypeText = {

--- a/webui/src/monitor/components/RecordTable/index.vue
+++ b/webui/src/monitor/components/RecordTable/index.vue
@@ -125,7 +125,7 @@ export default {
           record.hostpath += `:${record.originRequest.port}`
         }
         if (splited.length) {
-          record.name += splited.slice(-1)[0]
+          record.name = splited.slice(-1)[0] + record.name
         }
         if (!record.name) {
           record.name = '/'

--- a/webui/src/monitor/components/RecordTable/prettySize.js
+++ b/webui/src/monitor/components/RecordTable/prettySize.js
@@ -1,0 +1,58 @@
+'use strict';
+/*
+Copyright (c) 2013, Yahoo! Inc. All rights reserved.
+Code licensed under the BSD License:
+http://yuilibrary.com/license/
+*/
+
+const sizes = [
+    'Bytes', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB'
+];
+
+/**
+Pretty print a size from bytes
+@method pretty
+@param {Number} size The number to pretty print
+@param {Boolean} [nospace=false] Don't print a space
+@param {Boolean} [one=false] Only print one character
+@param {Number} [places=1] Number of decimal places to return
+*/
+
+const prettySize = (size, nospace, one, places) => {
+    if (typeof nospace === 'object') {
+        const opts = nospace;
+        nospace = opts.nospace;
+        one = opts.one;
+        places = opts.places || 1;
+    } else {
+        places = places || 1;
+    }
+
+    let mysize;
+
+    sizes.forEach((unit, id) => {
+        if (one) {
+            unit = unit.slice(0, 1);
+        }
+        const s = Math.pow(1024, id);
+        let fixed;
+        if (size >= s) {
+            fixed = String((size / s).toFixed(places));
+            if (fixed.indexOf('.0') === fixed.length - 2) {
+                fixed = fixed.slice(0, -2);
+            }
+            mysize = fixed + (nospace ? '' : ' ') + unit;
+        }
+    });
+
+    // zero handling
+    // always prints in Bytes
+    if (!mysize) {
+        let unit = (one ? sizes[0].slice(0, 1) : sizes[0]);
+        mysize = '0' + (nospace ? '' : ' ') + unit;
+    }
+
+    return mysize;
+};
+
+export default prettySize;

--- a/webui/yarn.lock
+++ b/webui/yarn.lock
@@ -4307,10 +4307,6 @@ pretty-error@^2.0.2:
     renderkid "^2.0.1"
     utila "~0.4"
 
-prettysize@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/prettysize/-/prettysize-1.1.0.tgz#c6c52f87161ff172ea435f375f99831dd9a97bb0"
-
 prettytime@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/prettytime/-/prettytime-1.0.0.tgz#bdab4fd19aa267ca10159f70adf5f07fbcd188f8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,9 +14,9 @@
   version "5.2.0"
   resolved "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.0.tgz#b3c8e69f038835db1a7fdc0b3d879fc50506e29e"
 
-"@types/node@^9.4.7":
-  version "9.6.6"
-  resolved "https://registry.npmjs.org/@types/node/-/node-9.6.6.tgz#439b91f9caf3983cad2eef1e11f6bedcbf9431d2"
+"@types/node@<=9.6.13":
+  version "9.6.13"
+  resolved "https://registry.npmjs.org/@types/node/-/node-9.6.13.tgz#ab0e691f166500b04075a2f01ca49235ea58e816"
 
 JSONStream@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
## zan-proxy@4.0.14 (2018-07-05)

**Implemented enhancements:**

- [支持Host多选](https://github.com/youzan/zan-proxy/issues/24) #24
- [支持转发规则集信息编辑](https://github.com/youzan/zan-proxy/pull/30)
- [使用fs.realpathSync判断dataFileRealPath是否包含mockDataDir](https://github.com/youzan/zan-proxy/pull/25)
- 优化构建命令
- 增加更新提示

**Fixed bugs:**

- [修复@types/node版本过高导致构建失败的问题](https://github.com/youzan/zan-proxy/issues/27) #27 
- [删除特殊字符的规则时报错](https://github.com/youzan/zan-proxy/pull/28)
- 修复监控器请求数据展示异常
- 兼容没有action的老数据