### PR TITLE
请求监控模块，复制curl时增加代理服务器参数

### DIFF
--- a/src/App/manager/controller/httpTraffic.ts
+++ b/src/App/manager/controller/httpTraffic.ts
@@ -6,6 +6,11 @@ export class HttpTrafficController {
   @Inject()
   private httpTrafficService: HttpTrafficService;
   public regist(router) {
+    // 获取proxy设置
+    router.get('/traffic/getProxyConfig', ctx => {
+      const content = this.httpTrafficService.getProxyConfig();
+      ctx.body = content;
+    });
     // 获取响应body
     router.get('/traffic/getResponseBody', async ctx => {
       const userId = ctx.userId;

--- a/src/App/services/httpTraffic.ts
+++ b/src/App/services/httpTraffic.ts
@@ -20,6 +20,7 @@ export class HttpTrafficService extends EventEmitter {
   private trafficDir: string;
   private filterMap: object;
   private stopRecord: object;
+  private appInfoService: AppInfoService;
   constructor(appInfoService: AppInfoService) {
     super();
     // http请求缓存数据 userId - > [{record}，{record}，{record}]
@@ -29,6 +30,7 @@ export class HttpTrafficService extends EventEmitter {
     // 记录用户的监视窗数量
     this.userMonitorCount = {};
 
+    this.appInfoService = appInfoService;
     const proxyDataDir = appInfoService.getProxyDataDir();
     // 监控数据缓存目录
     this.trafficDir = path.join(proxyDataDir, 'traffic');
@@ -229,6 +231,16 @@ export class HttpTrafficService extends EventEmitter {
       const bodyPath = this.getResponseBodyPath(userId, id);
       await fsWriteFile(bodyPath, body, { encoding: 'utf-8' });
     }
+  }
+
+  /**
+   * 获取proxy的设置
+   */
+  public getProxyConfig() {
+    return {
+      host: this.appInfoService.getPcIp(),
+      port: this.appInfoService.getHttpProxyPort()
+    };
   }
 
   /**

--- a/webui/src/api/traffic.js
+++ b/webui/src/api/traffic.js
@@ -1,5 +1,14 @@
 import axios from "axios";
 import queryString from "query-string";
+export async function getProxyConfig() {
+  try{
+    let result = await axios.get(`/traffic/getProxyConfig`);
+    return result.data;
+  }catch (e){
+    return '';
+  }
+
+}
 export async function getResponseBody(id) {
   try{
     let result = await axios.get(`/traffic/getResponseBody?id=${id}`);

--- a/webui/src/monitor/App.vue
+++ b/webui/src/monitor/App.vue
@@ -50,7 +50,11 @@
                     stopRecord: false, // 停止记录
                     overflow: false // 打到最大记录数显示
                 },
-                filter: ''
+                filter: '',
+                proxyServer: {
+                    host: '',
+                    port: ''
+                }
             };
         },
         computed: {
@@ -236,12 +240,20 @@
                 deep: true
             }
         },
-        created() {
+        async created() {
             this.calcSize();
 
             $(window).resize(_.debounce(this.calcSize, 200));
 
             if (!window.io) return;
+
+            try {
+                this.proxyServer = await trafficApi.getProxyConfig();
+                console.log(this.proxyServer)
+            } catch (e) {
+                console.error(e);
+            }
+            
             let socket = io('/httptrafic');
             socket.on('rows', this.receiveTraffic);
             socket.on('filter', filter => {

--- a/webui/src/monitor/components/RecordDetail/Request.vue
+++ b/webui/src/monitor/components/RecordDetail/Request.vue
@@ -67,8 +67,9 @@ export default {
         },
         curl() {
             const data = this.$dc.currentRow
+            const proxy = this.$dc.proxyServer
             return makeCURL({
-                ...data.originRequest,
+                ...data.originRequest, proxy,
                 body: this.$dc.currentRequestBody || '',
             })
         }

--- a/webui/src/monitor/components/RecordDetail/makeCURL.js
+++ b/webui/src/monitor/components/RecordDetail/makeCURL.js
@@ -2,6 +2,7 @@ import shellEscape from 'shell-escape';
 import { isObject, isArray } from 'lodash'
 
 const makeCURL = ({
+    proxy,
     method,
     headers,
     body,
@@ -9,6 +10,12 @@ const makeCURL = ({
     auth
 }) => {
     const args = ['curl']
+    
+    // proxy
+    if (proxy.host) {
+        args.push('-x');
+        args.push(`http://${proxy.host}` + (proxy.port ? `:${proxy.port}` : ''));
+    }
     
     // method
     args.push('-X')


### PR DESCRIPTION
![20180813175530](https://user-images.githubusercontent.com/11661891/44025285-4488240e-9f22-11e8-9fa0-70ecbe192396.png)
"Copy as cURL"按钮，复制curl的时候，没有代理服务器的参数。
如果是在ZanProxy中设置的Hosts或者Http转发，则无法在其他机器或者本机的命令行中直接使用复制的curl进行请求。
本次改动在curl命令中增加了代理服务器的参数，可在本机的命令行中使用，也可分享给他人使用。