### PR TITLE
fix: 修复使用说明页面，'chrome 代理设置指南' 链接错误的问题

### DIFF
--- a/webui/src/manager/components/help/Install.vue
+++ b/webui/src/manager/components/help/Install.vue
@@ -16,7 +16,7 @@
 
     <ol>
       <li>安装完插件后请设置插件代理地址为<code>127.0.0.1</code>，代理协议: http，端口为<code>zanProxy</code>代理端口(默认8001)。</li>
-      <li>如不清楚如何配置 SwitchyOmega，请参考 <a href="/help/chrome/" target="_blank">chrome 代理设置指南</a></li>
+      <li>如不清楚如何配置 SwitchyOmega，请参考 <a href="https://youzan.github.io/zan-proxy/book/usage/chrome.html" target="_blank">chrome 代理设置指南</a></li>
     </ol>
 
     <h2 id="toc_3">三、证书安装</h2>


### PR DESCRIPTION
fixes #69 