### PR TITLE
优化应用的交互

### DIFF
--- a/webui/build/dev-server.js
+++ b/webui/build/dev-server.js
@@ -60,7 +60,7 @@ app.use(hotMiddleware)
 
 // serve pure static assets
 var staticPath = path.posix.join(config.dev.assetsPublicPath, config.dev.assetsSubDirectory)
-app.use(staticPath, express.static('./static'))
+app.use(staticPath, express.static('../dist'))
 
 var uri = 'http://localhost:' + port
 

--- a/webui/src/manager/App.vue
+++ b/webui/src/manager/App.vue
@@ -153,7 +153,7 @@
                     projectPath: [],
                     enableRule: false
                 },
-                // 将工程路径配置转换为数组格式 方便编辑
+                // 将转发变量配置转换为数组格式 方便编辑
                 projectPathArray: [],
                 // 关联的ip
                 mappedClientIps: [],
@@ -206,7 +206,7 @@
             selectedRuleFiles() {
                 return this.ruleFileList.filter(f => f.checked).map(f => f.name)
             }
-            
+
         },
         methods: {
             async switchHost(value){
@@ -523,7 +523,7 @@
             // 强制dialog渲染body部分, 对ele dialog hack的初始化方式，原始的dialog不提供mouted后的事件
             this.$refs.mockDataDialg.rendered = true;
         },
-        
+
         watch: {
             profile() {
                 if (this.profile.enableHost && this.selectedHost) {

--- a/webui/src/manager/components/common/LeftMenu.vue
+++ b/webui/src/manager/components/common/LeftMenu.vue
@@ -16,7 +16,7 @@
               <span class='menu-name'>{{item.name}}</span>
             </template>
             <!-- 子菜单 -->
-            <el-menu-item 
+            <el-menu-item
               v-for='(child,cindex) in item.children'
               :style="{'padding-left':'40px'}"
               :index='index+"-"+cindex'
@@ -49,11 +49,6 @@ const menuList = [
     link: 'helpinstall'
   },
   {
-    name: '工程路径配置',
-    icon: 'icon-layers',
-    link: 'projectpath'
-  },
-  {
     name: 'Host 管理',
     icon: 'icon-box',
     link: 'hostfilelist'
@@ -62,6 +57,11 @@ const menuList = [
     name: 'Http 转发',
     icon: 'icon-skip',
     link: 'rulefilelist'
+  },
+  {
+    name: '转发变量配置',
+    icon: 'icon-layers',
+    link: 'projectpath'
   },
   {
     name: '自定义 mock 数据',

--- a/webui/src/manager/components/configure/ProjectPath.vue
+++ b/webui/src/manager/components/configure/ProjectPath.vue
@@ -1,48 +1,23 @@
 <template>
   <div>
-    <div class="main-content__title">工程路径管理</div>
-    <!-- <el-form label-width="100px">
-      <template v-for="(obj ,index) in $dc.projectPathArray">
-        <el-form-item label="工程名">
-          <el-input v-model="obj.key" placeholder="工程名" />
-        </el-form-item>
-        <el-form-item label="路径">
-          <el-input v-model="obj.value" placeholder="工程在本地的绝对路径" />
-        </el-form-item>
-        <el-row :gutter="10" style="margin-top: 5px;">
-          <el-col :span="2">
-            <el-button
-              type="danger"
-              icon='delete'
-              size="mini"
-              @click='deleteParam(obj,index,projectPathArray)'
-            />
-          </el-col>
-        </el-row>
-      </template>
-      
-      <el-form-item>
-        <el-button @click="addParam">增加工程路径设置</el-button>
-        <el-button type="primary" @click="saveFile">保存</el-button>
-      </el-form-item>
-    </el-form> -->
+    <div class="main-content__title">转发变量管理</div>
     <el-row :gutter="20" style="margin-bottom: 10px">
       <el-col :span="6" :offset="18" style="text-align:right">
-        <el-button size="small" @click='saveFile' type="primary">保存工程路径设置</el-button>
-        <el-button size="small" @click='addParam'>增加工程路径设置</el-button>
+        <el-button size="small" @click='saveFile' type="primary">保存转发变量设置</el-button>
+        <el-button size="small" @click='addParam'>增加转发变量设置</el-button>
       </el-col>
     </el-row>
     <el-table border align='center' :data="$dc.projectPathArray">
       <el-table-column type="index" width="60">
       </el-table-column>
-      <el-table-column prop="key" label="工程名" width="200">
+      <el-table-column prop="key" label="变量名" width="200">
         <template scope='scope'>
-          <el-input v-model="scope.row.key" size="small" placeholder="请输入工程名"></el-input>
+          <el-input v-model="scope.row.key" size="small" placeholder="请输入变量名"></el-input>
         </template>
       </el-table-column>
-      <el-table-column prop="value" label="工程路径">
+      <el-table-column prop="value" label="变量值">
         <template scope='scope'>
-          <el-input v-model="scope.row.value" size="small" placeholder="请输入工程路径"></el-input>
+          <el-input v-model="scope.row.value" size="small" placeholder="请输入变量值"></el-input>
         </template>
       </el-table-column>
       <el-table-column label="操作" :width="136" :context="_self">
@@ -85,7 +60,7 @@ export default {
       const projectNames = Object.keys(projectPathMap)
       for(const k of projectNames) {
         if (k.includes('-')) {
-          this.$message.error(`工程名${k}包含非法字符"-"`);
+          this.$message.error(`变量名${k}包含非法字符"-"`);
           return
         }
       }

--- a/webui/src/manager/components/rule/EditRule.vue
+++ b/webui/src/manager/components/rule/EditRule.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
-    <div class="main-content__title">编辑规则集{{ loaded ? ': ' + (filecontent.name || '拼命加载中') : ': 拼命加载中' }}</div>
+    <div class="main-content__title">
+      <router-link class="main-content__title-link" to="/rulefilelist">规则集列表</router-link> / 编辑规则集{{ loaded ? ': ' + (filecontent.name || '拼命加载中') : ': 拼命加载中' }}</div>
     <span class="save-tip" v-if="loaded && filecontent.meta && filecontent.meta.remote">该规则集为远程规则集，重启同步后相关配置会被覆盖。如需永久保存修改，则可以复制该规则集成本地规则集。</span>
     <el-row :gutter="20" style="margin-bottom: 10px;text-align: right;">
       <el-col :span="6" :offset="18">
@@ -117,7 +118,7 @@
   import Vue from 'vue';
   import EditDialog from './EditRuleDialog';
   import EditRuleConfigDialog from './EditRuleConfigDialog.vue';
-  
+
   Vue.component(RuleDetail.name, RuleDetail);
 
   export default {
@@ -372,6 +373,10 @@
 </script>
 
 <style scoped>
+  .main-content__title-link {
+    color: #20a0ff;
+    text-decoration: none;
+  }
   .save-tip {
     font-size: 14px;
     color: #999999;

--- a/webui/src/manager/components/rule/FileList.vue
+++ b/webui/src/manager/components/rule/FileList.vue
@@ -249,7 +249,7 @@ export default {
             content.name
           },引用变量【${varNameList.join(
             '; '
-          )}】请确保变量已经在工程路径配置中设置过值`;
+          )}】请确保变量已经在转发变量配置中设置过值`;
         } else {
           infoStr = `导入规则文件名为${content.name}`;
         }


### PR DESCRIPTION
1. 将“工程路径”重命名为“转发变量”，满足更多的需求，如图：
![2018-11-11 3 50 32](https://user-images.githubusercontent.com/19405002/48310505-51e6c480-e5cb-11e8-8c53-34381fbd1d75.png)
原因：举个例子，比如我们同时打开了多个转发规则，这些规则的转发地址包含的端口号在一开始配置的时候都是一样的，所以我们可能需要更改它们其中一个。对于这种场景如果能在配置地址的时候用占位符变量来替代常量，更改和查看起来会更加的方便。

2. 转发规则编辑页增加返回列表按钮，如图：
![2018-11-11 3 50 56](https://user-images.githubusercontent.com/19405002/48310503-4e533d80-e5cb-11e8-9221-dc98d6fd872f.png)

3. 调整目录结构，转发变量配置菜单项下移