### PR TITLE
fix: remove debounce, avoid check status asynchrony

### DIFF
--- a/webui/src/api/host.js
+++ b/webui/src/api/host.js
@@ -36,9 +36,9 @@ var api = {
         return axios.get(`/host/import?url=${encodeURIComponent(url)}`)
     },
 };
-api.debouncedUseFile = _.debounce(function (name, callback) {
+api.debouncedUseFile = function (name, callback) {
     api.toggleFile(name).then((response) => {
         callback(response)
     });
-}, 500);
+}
 export default  api;


### PR DESCRIPTION
现在最新的master build之后设置转发规则的时候切换会出现check与最顶上的list不同步的问题，这个问题出现在连续快速点击两次check box。

![image](https://user-images.githubusercontent.com/20221600/50511845-33c91b00-0aca-11e9-9d60-d0361fb8a61a.png)

经过测试定位到是因为debounce导致的，而且转发规则是没有设置debounce的，如果这个debounce没有必要使用的话建议删除掉