### PR TITLE
fix: revert pem lib version，fix gui main process bind error

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "open": "0.0.5",
     "ora": "^3.2.0",
     "parse-domain": "^2.1.7",
-    "pem": "^1.14.2",
+    "pem": "1.12.5",
     "promise.prototype.finally": "^3.1.0",
     "raw-body": "^2.3.3",
     "reflect-metadata": "^0.1.13",

--- a/src/gui/main/index.ts
+++ b/src/gui/main/index.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import * as path from 'path';
-import logger from 'electron-log';
+import * as logger from 'electron-log';
 import promiseFinally from 'promise.prototype.finally';
 
 promiseFinally.shim();
@@ -11,7 +11,7 @@ if (process.env.NODE_ENV === 'development') {
 } else {
   logger.transports.console.level = false;
   console.info = logger.info.bind(logger);
-  console.log = logger.log.bind(logger);
+  console.log = logger.info.bind(logger);
   console.error = logger.error.bind(logger);
   global.__root = path.resolve(__dirname, '../');
   global.__site = path.resolve(__dirname, '../site');

--- a/yarn.lock
+++ b/yarn.lock
@@ -4043,10 +4043,6 @@ es6-promisify@^5.0.0:
   dependencies:
     es6-promise "^4.0.3"
 
-es6-promisify@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.0.0.tgz#b526a75eaa5ca600e960bf3d5ad98c40d75c7203"
-
 es6-promisify@^6.0.1:
   version "6.0.1"
   resolved "http://registry.npm.taobao.org/es6-promisify/download/es6-promisify-6.0.1.tgz#6edaa45f3bd570ffe08febce66f7116be4b1cdb6"
@@ -8912,15 +8908,15 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-pem@^1.14.2:
-  version "1.14.2"
-  resolved "http://registry.npm.taobao.org/pem/download/pem-1.14.2.tgz#ab29350416bc3a532c30beeee0d541af897fb9ac"
-  integrity sha1-qyk1BBa8OlMsML7u4NVBr4l/uaw=
+pem@1.12.5:
+  version "1.12.5"
+  resolved "http://registry.npm.taobao.org/pem/download/pem-1.12.5.tgz#97bf2e459537c54e0ee5b0aa11b5ca18d6b5fef2"
+  integrity sha1-l78uRZU3xU4O5bCqEbXKGNa1/vI=
   dependencies:
-    es6-promisify "^6.0.0"
     md5 "^2.2.1"
     os-tmpdir "^1.0.1"
-    which "^1.3.1"
+    safe-buffer "^5.1.1"
+    which "^1.2.4"
 
 pend@~1.2.0:
   version "1.2.0"
@@ -12287,7 +12283,7 @@ which@1, which@^1.2.9, which@^1.3.0:
   dependencies:
     isexe "^2.0.0"
 
-which@1.3.1, which@^1.2.10, which@^1.2.14, which@^1.3.1:
+which@1.3.1, which@^1.2.10, which@^1.2.14, which@^1.2.4, which@^1.3.1:
   version "1.3.1"
   resolved "http://registry.npm.taobao.org/which/download/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=


### PR DESCRIPTION
- revert pem lib version and fixed it，because new version change api use way
- fix `bind` call error on gui build version, because electron-log has no `log` method