### PR TITLE
feat: support setting manager host

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,6 +41,7 @@ program
   .description('start ZanProxy server')
   .option('-p, --proxy_port [value]', 'set the proxy port')
   .option('-m, --manager_port [value]', 'set the manager server port')
+  .option('-mh, --manager_host [value]', 'set the manager server host')
   .option('--no-update', 'do not check if update available')
   .option('--no-sync', 'do not sync remote rules')
   .parse(process.argv);
@@ -55,8 +56,9 @@ async function run() {
     await syncHost();
   }
   const managerPort = program.manager_port || 40001;
-  const url = `http://${ip.address()}:${managerPort}`;
-  await start(program.proxy_port, program.manager_port);
+  const managerHost = program.manager_host || ip.address();
+  const url = `http://${managerHost}:${managerPort}`;
+  await start(program.proxy_port, program.manager_port, program.manager_host);
   open(url);
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,7 +41,7 @@ program
   .description('start ZanProxy server')
   .option('-p, --proxy_port [value]', 'set the proxy port')
   .option('-m, --manager_port [value]', 'set the manager server port')
-  .option('-mh, --manager_host [value]', 'set the manager server host')
+  .option('--manager_host [value]', 'set the manager server host')
   .option('--no-update', 'do not check if update available')
   .option('--no-sync', 'do not sync remote rules')
   .parse(process.argv);

--- a/src/core/App/index.ts
+++ b/src/core/App/index.ts
@@ -8,14 +8,17 @@ export default class App {
   @Inject() private proxy: Proxy;
   @Inject() private manager: Manager;
 
-  public async start(proxyPort: number = 8001, managerPort: number = 40001) {
+  public async start(proxyPort: number = 8001, managerPort: number = 40001, managerHost: string) {
     const appInfoService: AppInfoService = Container.get(AppInfoService);
     this.proxy.ignore(`127.0.0.1:${managerPort}`);
-    this.proxy.ignore(`${appInfoService.getPcIp()}:${managerPort}`);
+    this.proxy.ignore(`${managerHost || appInfoService.getPcIp()}:${managerPort}`);
     this.proxy.listen(proxyPort);
-    this.manager.listen(managerPort);
+    this.manager.listen(managerPort, managerHost);
     appInfoService.setHttpProxyPort(proxyPort);
     appInfoService.setRealUiPort(managerPort);
+    if (managerHost) {
+      appInfoService.setRealUiHost(managerHost);
+    }
     appInfoService.printRuntimeInfo();
   }
 

--- a/src/core/App/manager/index.ts
+++ b/src/core/App/manager/index.ts
@@ -77,9 +77,9 @@ export class Manager {
     this._initManger();
   }
 
-  public listen(port) {
+  public listen(port, host?) {
     // 启动server
-    this.server.listen(port);
+    this.server.listen(port, host);
   }
 
   // http流量监控界面

--- a/src/core/App/services/appInfo.ts
+++ b/src/core/App/services/appInfo.ts
@@ -82,6 +82,16 @@ export class AppInfoService extends EventEmitter {
   }
 
   /**
+   * 设置真实的 ui host
+   * @param uiport
+   */
+  public setRealUiHost(uihost) {
+    this.setAppInfo({
+      pcIp: uihost,
+    });
+  }
+
+  /**
    * 真实的代理端口
    * @returns {string}
    */

--- a/src/core/start.ts
+++ b/src/core/start.ts
@@ -1,8 +1,8 @@
 import { Container } from 'typedi';
 import App from './App';
 
-export default async (proxyPort?, uiPort?) => {
+export default async (proxyPort?, uiPort?, uiHost?) => {
   const app = Container.get(App);
   await app.init();
-  await app.start(proxyPort, uiPort);
+  await app.start(proxyPort, uiPort, uiHost);
 };


### PR DESCRIPTION
### 这是一个什么样的功能？

支持设置管理服务器的 host

### 这个功能可以解决什么问题？

现在的管理服务器局域网内任何人都可以访问，有安全隐患，设置管理服务器的 host 为 127.0.0.1 可以阻止外部访问，提高安全性

`zan-proxy --manager_host 127.0.0.1`

### 进一步

为了更好的安全性，应该采取像 webpack-dev-server [默认阻止外部访问](https://webpack.docschina.org/configuration/dev-server/#devserver-hot)的方式，但这个 pr 为了不影响原有功能并没有这样做，不知道你们愿不愿意这样改？