### PR TITLE
[bugfix]: 修复 content-type 头不存在时的报错

### DIFF
--- a/src/core/proxy/middleware/forward.ts
+++ b/src/core/proxy/middleware/forward.ts
@@ -38,7 +38,7 @@ export class ForwarderMiddleware implements IProxyMiddleware {
     }
 
     // node version under v11.7.0, not support brotli algorithm
-    if (!isSupportBrotli && options.headers) {
+    if (!isSupportBrotli && options.headers && options.headers['accept-encoding']) {
       const accpetEncoding = options.headers['accept-encoding'] as string;
       accpetEncoding
         .split(',')


### PR DESCRIPTION
- 添加 accept-encoding header 头是否存在的判断